### PR TITLE
Upgrade scikit-learn to 1.5.0 to fix dependabot issue

### DIFF
--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -61,7 +61,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/BigDL',
         packages=get_bigdl_packages(),
-        install_requires=['pandas>=1.0.5, <=1.3.5', 'scikit-learn>=0.22.0, <=1.0.2',
+        install_requires=['pandas>=1.0.5, <=1.3.5', 'scikit-learn>=1.5.0',
                           'bigdl-nano==' + VERSION, 'numpy<=1.23.5'],
         extras_require={'pytorch': ['bigdl-nano[pytorch]==' + VERSION],
                         'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Upgrade scikit-learn to 1.5.0 to fix dependabot issue: https://github.com/intel-analytics/BigDL-2.x/security/dependabot/501